### PR TITLE
Correct database deployment yaml file

### DIFF
--- a/ch05/database.yaml
+++ b/ch05/database.yaml
@@ -24,8 +24,14 @@ spec:
         app: visitors
         tier: mysql
     spec:
+      volumes:
+      - name: mysql-vol
+        emptyDir: {}
       containers:
         - name: visitors-mysql
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: mysql-vol
           image: "mysql:5.7"
           imagePullPolicy: Always
           ports:


### PR DESCRIPTION
On OpenShift 4.4, the database deployment fails with the following error:

```
020-07-28 17:37:03+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.31-1debian10 started.
2020-07-28 17:37:03+00:00 [Note] [Entrypoint]: Initializing database files
mysqld: Can't create/write to file '/var/lib/mysql/is_writable' (Errcode: 13 - Permission denied)
2020-07-28T17:37:03.256943Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2020-07-28T17:37:03.258135Z 0 [ERROR] --initialize specified but the data directory exists and is not writable. Aborting.
2020-07-28T17:37:03.258149Z 0 [ERROR] Aborting
``` 

This change fixes the error and makes deployment possible (while keeping the mount ephemeral).