### PR TITLE
Fix #10

### DIFF
--- a/ch03/etcd-operator-crd.yaml
+++ b/ch03/etcd-operator-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,8 +13,18 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
   versions:
   - name: v1beta2
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              size:
+                type: integer
+              version:
+                type: string


### PR DESCRIPTION
For kubernetes v1.19+, use the api group `apiextensions.k8s.io/v1'

refs:
- https://github.com/kubernetes-operators-book/chapters/issues/10#issuecomment-1159458099
- https://github.com/kubernetes/kubernetes/pull/79604
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/

Signed-off-by: flavono123 <flavono123@gmail.com>